### PR TITLE
Fix #14 - constantly regenerating recipes.

### DIFF
--- a/src/main/java/omtteam/ompd/handler/recipes/RecipeHandler.java
+++ b/src/main/java/omtteam/ompd/handler/recipes/RecipeHandler.java
@@ -9,6 +9,14 @@ import omtteam.ompd.handler.ConfigHandler;
 import omtteam.ompd.init.ModBlocks;
 
 public class RecipeHandler {
+    /**
+     * Set this to true in order to generate recipes. This should only be enabled if
+     * recipes need to be added, modified, or removed manually.
+     * <p>
+     * This should <b>never</b> be enabled outside of a development environment.
+     */
+    private static final boolean GENERATE_RECIPES = false;
+    
     public static ItemStack hardWallTierOne;
     public static ItemStack hardWallTierTwo;
     public static ItemStack hardWallTierThree;
@@ -23,6 +31,9 @@ public class RecipeHandler {
 
 
     public static void initRecipes() {
+        if (!GENERATE_RECIPES) {
+            return;
+        }
         hardWallTierOne = new ItemStack(ModBlocks.hardened, 16, 0);
         hardWallTierTwo = new ItemStack(ModBlocks.hardened, 16, 1);
         hardWallTierThree = new ItemStack(ModBlocks.hardened, 16, 2);


### PR DESCRIPTION
These probably don't need to be generated outside of a development environment, however I haven't removed the method as they might be useful in the future. A potential fix for #14.